### PR TITLE
Add admin mode with teacher login and protected roster actions

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -5,7 +5,8 @@ A super simple FastAPI application that allows students to view and sign up for 
 ## Features
 
 - View all available extracurricular activities
-- Sign up for activities
+- Teacher-only sign up/unregister actions
+- Login/logout with local teacher credentials from `teachers.json`
 
 ## Getting Started
 
@@ -31,6 +32,19 @@ A super simple FastAPI application that allows students to view and sign up for 
 | ------ | ----------------------------------------------------------------- | ------------------------------------------------------------------- |
 | GET    | `/activities`                                                     | Get all activities with their details and current participant count |
 | POST   | `/activities/{activity_name}/signup?email=student@mergington.edu` | Sign up for an activity                                             |
+| DELETE | `/activities/{activity_name}/unregister?email=student@mergington.edu` | Unregister from an activity                                    |
+| POST   | `/auth/login`                                                     | Teacher login                                                       |
+| POST   | `/auth/logout`                                                    | Teacher logout                                                      |
+| GET    | `/auth/status`                                                    | Check current teacher auth status                                   |
+
+## Teacher Credentials
+
+Teacher credentials are stored in `teachers.json` and validated by the backend.
+
+Example default credentials:
+
+- `teacher.alex` / `mergington123`
+- `teacher.jordan` / `school2026`
 
 ## Data Model
 

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -10,6 +10,25 @@
     <header>
       <h1>Mergington High School</h1>
       <h2>Extracurricular Activities</h2>
+      <div id="auth-controls">
+        <button id="user-menu-button" type="button" aria-label="User menu">👤</button>
+        <div id="auth-panel" class="hidden">
+          <p id="auth-status-text">Not logged in</p>
+          <button id="show-login-button" type="button">Login</button>
+          <form id="login-form" class="hidden">
+            <div class="form-group">
+              <label for="teacher-username">Username:</label>
+              <input type="text" id="teacher-username" required />
+            </div>
+            <div class="form-group">
+              <label for="teacher-password">Password:</label>
+              <input type="password" id="teacher-password" required />
+            </div>
+            <button type="submit">Sign In</button>
+          </form>
+          <button id="logout-button" type="button" class="hidden">Logout</button>
+        </div>
+      </div>
     </header>
 
     <main>
@@ -23,6 +42,9 @@
 
       <section id="signup-container">
         <h3>Sign Up for an Activity</h3>
+        <p id="signup-note" class="info">
+          Teachers must log in to register or unregister students.
+        </p>
         <form id="signup-form">
           <div class="form-group">
             <label for="email">Student Email:</label>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -16,6 +16,7 @@ body {
 }
 
 header {
+  position: relative;
   text-align: center;
   padding: 20px 0;
   margin-bottom: 30px;
@@ -26,6 +27,53 @@ header {
 
 header h1 {
   margin-bottom: 10px;
+}
+
+#auth-controls {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+}
+
+#user-menu-button {
+  background-color: #ffffff;
+  color: #1a237e;
+  border: 1px solid #c5cae9;
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  padding: 0;
+  font-size: 20px;
+  line-height: 1;
+}
+
+#auth-panel {
+  position: absolute;
+  top: 46px;
+  right: 0;
+  width: 260px;
+  padding: 12px;
+  background-color: white;
+  border: 1px solid #ddd;
+  border-radius: 5px;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.15);
+  color: #333;
+  text-align: left;
+  z-index: 10;
+}
+
+#auth-panel p {
+  margin-bottom: 10px;
+}
+
+#auth-panel button {
+  width: 100%;
+  margin-bottom: 8px;
+}
+
+#auth-panel .form-group input {
+  padding: 8px;
+  font-size: 14px;
 }
 
 main {

--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,12 @@
+{
+  "teachers": [
+    {
+      "username": "teacher.alex",
+      "password": "mergington123"
+    },
+    {
+      "username": "teacher.jordan",
+      "password": "school2026"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add teacher login/logout endpoints with cookie-based sessions
- enforce teacher authentication for signup/unregister actions
- add top-right user icon and login panel in the UI
- hide roster write controls unless a teacher is logged in
- add JSON-backed teacher credentials file and docs updates

## Validation
- verified unauthenticated signup returns `401`
- verified teacher login succeeds
- verified authenticated signup/unregister succeeds